### PR TITLE
fix warnings on state.when; try to add centos8; change vagrant boxes …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.egg-info
 build/
 dist/
+venv/
+.*swp
+pyinfra-debug.log
 
 .vagrant*
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,8 @@
 # pyinfra-docker Example
 
-Targets latest distributions: Ubuntu 16, Debian 8 and CentOS 7.
+Targets distributions: Ubuntu 16/18, Debian 9/10 and CentOS 7.
+
+Note: Could not get docker-ce to work on Centos8.
 
 ## Quickstart
 
@@ -10,9 +12,23 @@ Requirements:
 + [pyinfra](https://github.com/Fizzadar/pyinfra) >= 0.5
 
 ```sh
-# Bring up the VMs
+# Bring up the virtual machine instances
 vagrant up
 
-# Deploy an etcd cluster on them
+# Create a python virtual environment for pyinfra using python3
+virtualenv -p python3 venv
+
+# Activate python virtual environment
+source venv/bin/activate
+
+# Install pyinfra into the python virtual environment
+pip install pyinfra
+
+# Install pyinfra-docker into the python virtual environment
+cd ..
+python setup.py install
+
+# Deploy docker to each virtual machine
+cd example
 pyinfra @vagrant deploy.py
 ```

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -3,14 +3,23 @@ Vagrant.configure('2') do |config|
     config.vm.synced_folder '.', '/vagrant', disabled: true
 
     config.vm.define :ubuntu16 do |ubuntu|
-        ubuntu.vm.box = 'geerlingguy/ubuntu1604'
+        ubuntu.vm.box = 'bento/ubuntu-16.04'
     end
 
-    config.vm.define :debian8 do |debian|
-        debian.vm.box = 'debian/jessie64'
+    config.vm.define :ubuntu18 do |ubuntu|
+        ubuntu.vm.box = 'bento/ubuntu-18.04'
+    end
+
+    config.vm.define :debian9 do |debian|
+        debian.vm.box = 'bento/debian-9.11'
+    end
+
+    config.vm.define :debian10 do |debian|
+        debian.vm.box = 'bento/debian-10'
     end
 
     config.vm.define :centos7 do |centos|
-        centos.vm.box = 'centos/7'
+        centos.vm.box = 'bento/centos-7'
     end
+
 end


### PR DESCRIPTION
…to ones that have both vagrant and vmware

Let me know if you want to change anything.

It feels like we should have something like:

```
server.shell(
    {'Run simple docker hello'},
    'echo "docker run --rm hello-world"',
)
```

at the end to verify/validate docker works as expected or something. Maybe?