### PR TITLE
Use `server.service` in `deploy.py` example

### DIFF
--- a/example/deploy.py
+++ b/example/deploy.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import init
+from pyinfra.operations import server
 from pyinfra_docker import deploy_docker
 
 
@@ -11,7 +11,7 @@ deploy_docker(config={
 })
 
 
-init.service(
+server.service(
     'docker',
     running=True,
 )


### PR DESCRIPTION
* In the newer versions (like 1.4.2) of `pyinfra` the `server.service` operation is preferred, in contrast with the previously used `init.service`

* This PR makes the example code in `deploy.py` use the newer operation.